### PR TITLE
21 5 2024 kandepranathi

### DIFF
--- a/.dist/tasks/force-app/main/default/classes/OpportunityTriggerHandler.cls
+++ b/.dist/tasks/force-app/main/default/classes/OpportunityTriggerHandler.cls
@@ -1,38 +1,38 @@
 public with sharing class OpportunityTriggerHandler {
     public static void Updateuniquenames(List<Opportunity>oppRecords)
     {
-        Map<Id,Integer>Accountcount=new Map<Id,Integer>();
-            Map<Id,String>Accountwname=new Map<Id,String>();
+        Map<Id,Integer>OppwIdandcount=new Map<Id,Integer>();
+            Map<Id,String>Accountidwname=new Map<Id,String>();
             Integer oppCount=0;
             List<Opportunity>oppnames=new List<Opportunity>();
             for(Opportunity opp:oppRecords)
             {
                 if(opp.AccountId!=null)
                 {
-                    Accountwname.put(opp.AccountId,opp.Account.Name);
+                    Accountidwname.put(opp.AccountId,opp.Account.Name);
                 }
             }
-            List<Account> oppcounts=[select id,(select id from Opportunities) from Account where id in:Accountwname.keyset()];
+            List<Account> oppcounts=[select id,(select id from Opportunities) from Account where id in:Accountidwname.keyset()];
             if(!oppcounts.isEmpty())
             {
                 for(Account o:oppcounts)
                 {
                     oppCount=o.Opportunities.size();
-                    Accountcount.put(o.id,oppCount);
+                    OppwIdandcount.put(o.id,oppCount);
                 }
             }
             for(Opportunity opp1:oppRecords)
             {
                 Account accountname=[select Name from Account where Id=:opp1.AccountId];
-                if(opp1.AccountId!=null && Accountcount.containsKey(opp1.AccountId))
+                if(opp1.AccountId!=null && OppwIdandcount.containsKey(opp1.AccountId))
                 {
-                    oppCount=Accountcount.get(opp1.AccountId)+1;
+                    oppCount=OppwIdandcount.get(opp1.AccountId)+1;
                     opp1.uniquename__c=accountname.Name+'Opp00'+String.valueOf(oppCount);
                 }
                 else
                 {
                     oppCount+=1;
-                    Accountcount.put(opp1.AccountId,oppCount);
+                    OppwIdandcount.put(opp1.AccountId,oppCount);
                     opp1.uniquename__c=accountname.Name+'Opp00'+String.valueOf(oppCount);
                 }
             }

--- a/.dist/tasks/force-app/main/default/classes/OpportunityTriggerHandler.cls
+++ b/.dist/tasks/force-app/main/default/classes/OpportunityTriggerHandler.cls
@@ -1,39 +1,42 @@
-public with sharing class OpportunityTriggerHandler {
+public class oppTriggerHandler {
     public static void Updateuniquenames(List<Opportunity>oppRecords)
     {
-        Map<Id,Integer>OppwIdandcount=new Map<Id,Integer>();
-            Map<Id,String>Accountidwname=new Map<Id,String>();
-            Integer oppCount=0;
-            List<Opportunity>oppnames=new List<Opportunity>();
-            for(Opportunity opp:oppRecords)
-            {
-                if(opp.AccountId!=null)
-                {
-                    Accountidwname.put(opp.AccountId,opp.Account.Name);
-                }
-            }
-            List<Account> oppcounts=[select id,(select id from Opportunities) from Account where id in:Accountidwname.keyset()];
+        Map<Id,Integer>oppwIdAndCount=new Map<Id,Integer>();
+        Map<Id,String>accountidwName=new Map<Id,String>();
+        set<Id>accountIds=new set<Id>();
+        Integer oppCount=0;
+        List<Opportunity>oppNames=new List<Opportunity>();
+        for(Opportunity opp:oppRecords)
+        {
+          if(opp.AccountId!=null)
+          {
+              AccountIds.add(opp.AccountId);
+                    
+          }
+        }
+            List<Account> oppcounts=[Select id,name,(Select id from Opportunities) from Account where id in:AccountIds];
             if(!oppcounts.isEmpty())
             {
                 for(Account o:oppcounts)
                 {
                     oppCount=o.Opportunities.size();
                     OppwIdandcount.put(o.id,oppCount);
+                    Accountidwname.put(o.Id,o.Name);
                 }
             }
             for(Opportunity opp1:oppRecords)
             {
-                Account accountname=[select Name from Account where Id=:opp1.AccountId];
+                //Account accountname=[Select Name from Account where Id=:opp1.AccountId];
                 if(opp1.AccountId!=null && OppwIdandcount.containsKey(opp1.AccountId))
                 {
                     oppCount=OppwIdandcount.get(opp1.AccountId)+1;
-                    opp1.uniquename__c=accountname.Name+'Opp00'+String.valueOf(oppCount);
+                    opp1.uniquename__c=accountidwName.get(opp1.AccountId)+'Opp00'+String.valueOf(oppCount);
                 }
                 else
                 {
                     oppCount+=1;
                     OppwIdandcount.put(opp1.AccountId,oppCount);
-                    opp1.uniquename__c=accountname.Name+'Opp00'+String.valueOf(oppCount);
+                    opp1.uniquename__c=accountidwName.get(opp1.AccountId)+'Opp00'+String.valueOf(oppCount);
                 }
             }
     }

--- a/.dist/tasks/force-app/main/default/classes/OpportunityTriggerHandler.cls
+++ b/.dist/tasks/force-app/main/default/classes/OpportunityTriggerHandler.cls
@@ -1,0 +1,53 @@
+public with sharing class OpportunityTriggerHandler {
+    public static void Updateuniquenames(List<Opportunity>oppRecords)
+    {
+        Map<Id,Integer>Accountcount=new Map<Id,Integer>();
+            Map<Id,String>Accountwname=new Map<Id,String>();
+            Integer oppCount=0;
+            List<Opportunity>oppnames=new List<Opportunity>();
+            for(Opportunity opp:oppRecords)
+            {
+                if(opp.AccountId!=null)
+                {
+                    Accountwname.put(opp.AccountId,opp.Account.Name);
+                }
+            }
+            List<Account> oppcounts=[select id,(select id from Opportunities) from Account where id in:Accountwname.keyset()];
+            if(!oppcounts.isEmpty())
+            {
+                for(Account o:oppcounts)
+                {
+                    oppCount=o.Opportunities.size();
+                    Accountcount.put(o.id,oppCount);
+                }
+            }
+            for(Opportunity opp1:oppRecords)
+            {
+                Account accountname=[select Name from Account where Id=:opp1.AccountId];
+                if(opp1.AccountId!=null && Accountcount.containsKey(opp1.AccountId))
+                {
+                    oppCount=Accountcount.get(opp1.AccountId)+1;
+                    opp1.uniquename__c=accountname.Name+'Opp00'+String.valueOf(oppCount);
+                }
+                else
+                {
+                    oppCount+=1;
+                    Accountcount.put(opp1.AccountId,oppCount);
+                    opp1.uniquename__c=accountname.Name+'Opp00'+String.valueOf(oppCount);
+                }
+            }
+    }
+    public static void updatewhenaccountwaschanged(List<Opportunity>oppRecords,Map<Id,Opportunity>oldRecords)
+    {
+        List<Opportunity>oppotunityrecords=new List<Opportunity>();
+        for(Opportunity opp:oppRecords)
+        {
+            if(opp.AccountId!=null && oldRecords.get(opp.Id).accountId!=opp.AccountId)
+            {
+                oppotunityrecords.add(opp);
+            }
+        }
+        Updateuniquenames(oppotunityrecords);
+    }
+
+}

--- a/.dist/tasks/force-app/main/default/classes/opportunityTestClass.cls
+++ b/.dist/tasks/force-app/main/default/classes/opportunityTestClass.cls
@@ -1,0 +1,74 @@
+@isTest
+public class oppTestClass {
+    @testSetup
+    public static void createTestData() {
+        Account acc1 = new Account(Name = 'TestAccount1');
+        Account acc2 = new Account(Name = 'TestAccount2');
+        insert new List<Account>{acc1, acc2};
+
+        List<Opportunity> oppRecords = new List<Opportunity>();
+        for (Integer i = 0; i < 2; i++) {
+            Opportunity opp = new Opportunity(
+                Name = 'TestOpp' + i,
+                StageName = 'Prospecting',
+                CloseDate = Date.Today().addDays(7),
+                AccountId = acc1.Id
+            );
+            oppRecords.add(opp);
+        }
+        insert oppRecords;
+    }
+
+    @isTest
+    public static void autonumber() {
+        List<Opportunity> oppRecords = [SELECT Id, Name, uniquename__c FROM Opportunity ORDER BY CreatedDate];
+
+        Test.startTest();
+        for (Opportunity opp : oppRecords) {
+            System.assert(opp.uniquename__c.contains('TestAccount1Opp00'), 'uniquename__c should contain "TestAccount1Opp00"');
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    public static void accountUpdate() {
+        Account newAccount = [SELECT Id FROM Account WHERE Name = 'TestAccount2' LIMIT 1];
+        Opportunity oppToUpdate = [SELECT Id, AccountId, uniquename__c FROM Opportunity LIMIT 1];
+        String oldUniqueName = oppToUpdate.uniquename__c;
+        
+        oppToUpdate.AccountId = newAccount.Id;
+
+        Test.startTest();
+        update oppToUpdate;
+        Test.stopTest();
+
+        Opportunity updatedOpp = [SELECT Id, AccountId, uniquename__c, Account.Name FROM Opportunity WHERE Id = :oppToUpdate.Id];
+
+        System.assertNotEquals(oldUniqueName, updatedOpp.uniquename__c, 'uniquename__c should have changed.');
+        System.assert(updatedOpp.uniquename__c.contains('TestAccount2Opp00'),'its correct');
+    }
+
+    @isTest
+    public static void testUniqueNameForNewAccount() {
+        Account newAccount = new Account(Name = 'NewTestAccount');
+        insert newAccount;
+
+        Opportunity newOpp = new Opportunity(
+            Name = 'New Opportunity',
+            AccountId = newAccount.Id,
+            StageName = 'Prospecting',
+            CloseDate = Date.today()
+        );
+
+        Test.startTest();
+        insert newOpp;
+        Test.stopTest();
+
+        Opportunity insertedOpp = [SELECT Id, Name, uniquename__c, Account.Name FROM Opportunity WHERE Id = :newOpp.Id];
+        String expectedUniqueName = 'NewTestAccountOpp001';
+
+        System.assertEquals(expectedUniqueName, insertedOpp.uniquename__c);
+    }
+
+    
+}

--- a/.dist/tasks/force-app/main/default/triggers/OpportunityTrigger.trigger
+++ b/.dist/tasks/force-app/main/default/triggers/OpportunityTrigger.trigger
@@ -1,0 +1,14 @@
+trigger OpportunityTrigger on Opportunity (before insert,before update) {
+    if(Trigger.isBefore)
+    {
+        if(Trigger.isInsert)
+        {
+            opportunityTriggerHandler.Updateuniquenames(Trigger.new);
+        }
+        if(Trigger.isUpdate)
+        {
+            opportunityTriggerHandler.updatewhenaccountwaschanged(Trigger.new, Trigger.oldMap);
+        }
+    }
+
+}


### PR DESCRIPTION
Create an AutoNumber trigger that assigns unique numbers to Opportunities based on whether they are related to an Account, if the account is changed then updating the unique number for that respective opportunity.